### PR TITLE
unicorn.rbのtimeoutを延長

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -9,7 +9,7 @@ stderr_path "#{app_path}/shared/log/unicorn.stderr.log"
 stdout_path "#{app_path}/shared/log/unicorn.stdout.log"
 
 listen 3000
-timeout 60
+timeout 180
 
 preload_app true
 GC.respond_to?(:copy_on_write_friendly=) && GC.copy_on_write_friendly = true


### PR DESCRIPTION
## WHAT
timeoutを180に設定。

## WHY
timeoutを迎えてunicornのworkingProcessがkillされている。
エラーログ　worker=0 PID:27878 timeout (61s > 60s), killing