### PR TITLE
pickup, sliderのアソシエーションの修正

### DIFF
--- a/app/models/project_pickup.rb
+++ b/app/models/project_pickup.rb
@@ -1,3 +1,3 @@
 class ProjectPickup < ApplicationRecord
-  has_many   :projects
+  belongs_to   :project
 end

--- a/app/models/project_slider.rb
+++ b/app/models/project_slider.rb
@@ -1,3 +1,3 @@
 class ProjectSlider < ApplicationRecord
-  has_many   :projects
+  belongs_to   :project
 end


### PR DESCRIPTION
# WAHT
projectと、project_pickup・project_slider間のアソシエーションが間違っていたので修正

## project_slider
```
class ProjectSlider < ApplicationRecord
  belongs_to   :project
end
```

## project_pickup
```
class ProjectPickup < ApplicationRecord
  belongs_to   :project
end
```